### PR TITLE
Force load dx90.vtx instead of dx80.vtx

### DIFF
--- a/applypatch.py
+++ b/applypatch.py
@@ -25,7 +25,10 @@ patches32 = {
         ('8a81??030000c3cccccccccccccccccc8b', 0), # m_bForceNoVis [getter]
         ('cccccccccccccccccc8a814403', 9) # m_bForceNoVis [alt getter]
         ], 'b001c3'],
-]
+],
+'bin/datacache.dll': [
+    [('647838302e767478', 0), '647839302e767478'], # force load dx9 vtx
+],
 }
 
 # Incomplete Garry's Mod 64bit patches


### PR DESCRIPTION
I think portal rtx does this? But yeah for some games theres no dx80.vtx for models so we should use the more common dx90.vtx instead.

I think i did it right, i tested the patch in gmod and it worked